### PR TITLE
Fix the header and button on landing page

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -136,6 +136,27 @@ svg {
     }
 }
 
+@media (max-width: 375px) {
+    .button-container{
+        justify-content: flex-start;
+        max-width:1000px;
+        height: calc(100vh - 100px);
+        padding: 0 2rem;
+    }
+    .button {
+        width: 16rem;
+        height: 5rem;
+        font-size: 22px;
+    }
+
+    .button-container h1 {
+        font-size: 3.5rem;
+    }
+    #footer h2 {
+        font-size: 28px;
+    }
+
+}
 /* @media (max-width: 1024px) {
     .container {
         max-width: 1024px;

--- a/client/src/components/Filter.jsx
+++ b/client/src/components/Filter.jsx
@@ -85,7 +85,7 @@ function Filter() {
   return (
     <>
       <Element name="newHead">
-        <h2 style={{ marginBottom: "5%" }}>Contests</h2>
+        <h2 style={{ marginBottom: "5%", marginLeft:"1%", marginRight:"1%" }}>Contests</h2>
       </Element>
       {/* //checkmarks */}
       <div className={`filter-div`}>


### PR DESCRIPTION
# Description

The header and button do not fit in mobile smaller than 375px for example the smallest mobile @280px Galaxy Fold. Also, the project as forked doesn't look like the images provided in the issue. I only updated the Landing page header and button. 

![image](https://github.com/digitomize/digitomize/assets/97356401/69bca7b7-796b-420b-977f-50424a5abe34)


Fixes #117 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Responsive Testing?
(Only applicable for Frontend changes)
Checked for: (width in px)
- [X] Laptop L - 1440px
- [X] Laptop - 1024px
- [X] Tablet - 768px
- [X] Mobile M - 375px

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code

