### PR TITLE
Add install pwa custom prompt

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -5,7 +5,7 @@
   "background_color": "#1582ff",
   "display": "standalone",
   "scope": "https://deploy-preview-180--v2-digitomize.netlify.app/home/",
-  "start_url": "https://deploy-preview-180--v2-digitomize.netlify.app/home/",
+  "start_url": "/",
   "icons": [
     {
       "src": "https://res.cloudinary.com/dsazw0r59/image/upload/v1697627259/logox48.png",

--- a/client/src/components/InstallPWAButton.jsx
+++ b/client/src/components/InstallPWAButton.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import './css/InstallPWAButton.css';
+
+function InstallPWAButton() {
+  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
+  const [postponedPrompt, setPostponedPrompt] = useState(null);
+  // const [userDismissed, setUserDismissed] = useState(false);
+
+  useEffect(() => {
+    const hasUserDismissedPrompt = sessionStorage.getItem('user-dismissed-prompt');
+
+    if (hasUserDismissedPrompt) {
+      return;
+    }
+
+    const handleBeforeInstallPrompt = (e) => {
+      e.preventDefault();
+      setPostponedPrompt(e);
+      setShowInstallPrompt(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    };
+  }, []);
+
+
+  const onInstallClick = () => {
+    if (postponedPrompt) {
+      setShowInstallPrompt(false);
+      postponedPrompt.prompt();
+
+      postponedPrompt.userChoice.then((choiceResult) => {
+        if (choiceResult.outcome === 'dismissed') {
+          sessionStorage.setItem('user-dismissed-prompt', 'true');
+        }
+        setPostponedPrompt(null);
+      });
+    }
+  };
+
+
+  if (!showInstallPrompt) {
+    return null;
+  } else {
+    return (
+      <div className="install-prompt">
+        <p>Install our app for a better experience!</p>
+        <div className='installPromptButtonsDiv'>
+          <button onClick={onInstallClick}>Install</button>
+          <button onClick={() => setShowInstallPrompt(false)}>Remind me later</button>
+        </div>
+      </div>
+    );
+  }
+
+
+}
+
+export default InstallPWAButton;

--- a/client/src/components/css/InstallPWAButton.css
+++ b/client/src/components/css/InstallPWAButton.css
@@ -1,0 +1,67 @@
+.install-prompt {
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 20px;
+  background-color: #333;
+  color: #fff;
+  border-radius: 5px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  width: 90%;
+  max-width: 350px;
+}
+
+.install-prompt button {
+  background-color: #007BFF;
+  border: none;
+  color: white;
+  padding: 8px 20px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  margin: 4px 2px;
+  cursor: pointer;
+  border-radius: 4px;
+  width: fit-content;
+}
+
+.installPromptButtonsDiv {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+@media screen and (min-width: 768px) {
+  .install-prompt {
+    display: block;
+    top: 10px;
+    right: 10px;
+    left: auto;
+    bottom: auto;
+    transform: none;
+    flex-direction: row;
+    padding: 10px 20px;
+    width: auto;
+    max-width: none;
+  }
+
+  .install-prompt button {
+    font-size: 16px;
+    width: auto;
+    padding: 5px 15px;
+  }
+
+  .installPromptButtonsDiv {
+    flex-direction: row;
+    gap: 5%;
+  }
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -6,10 +6,11 @@ import App from './App'
 
 import "./index.css"
 import "tw-elements-react/dist/css/tw-elements-react.min.css";
+import InstallPWAButton from './components/InstallPWAButton';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-
+    <InstallPWAButton />
     <App />
   </React.StrictMode>
 )


### PR DESCRIPTION
# Description
Created a custom prompt for installation of pwa when the user visits the website. This custom prompt would redirect to the built-in installation prompt of pwa.

Fixes # (issue)
#195 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Responsive Testing?
(Only applicable for Frontend changes)
Checked for: (width in px)
- [x] Laptop L - 1440px
- [x] Laptop - 1024px
- [x] Tablet - 768px
- [x] Mobile M - 375px

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in modules

