### PR TITLE
Use postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@
 
 1. Clone the repository: `git clone https://github.com/pranshugupta54/digitomize.git`
 2. Install project dependencies and start the development environment: <br>
-   a. In the root directory of the project (where package.json is located), run `npm install`. <br>
-   b. Install backend and client dependencies together by `npm run installer`. <br>
+In the root directory of the project (where package.json is located), run `npm install`. <br>
 3. Configure environment variables: Create a .env file in the backend and client directories respectively, and set up the required environment variables such as database connection details, API keys, and other configurations.
 4. Start the development environment: `npm run dev` (This command, defined in your project's package.json, starts both the backend server and the client using the concurrently library. It's a convenient way to run both parts of your application concurrently during development.)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "digitomize",
             "version": "1.0.0",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "dotenv": "^16.3.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "installer": "concurrently \"cd backend && npm install\" \"cd client && npm install\"",
+        "postinstall": "concurrently \"cd backend && npm install\" \"cd client && npm install\"",
         "build": "concurrently \"cd backend && npm run start\" \"cd frontend && npm build\"",
         "dev": "concurrently \"cd backend && npm run dev\" \"cd client && npm run dev\"",
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
# Description

Hello, the `npm run installer` step can be run automatically after `npm install` in the root folder by using the `postinstall` script. I made this change to simplify the process of getting up and running. 😊

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Responsive Testing?
(Only applicable for Frontend changes)
Checked for: (width in px)
- [ ] Laptop L - 1440px
- [ ] Laptop - 1024px
- [ ] Tablet - 768px
- [ ] Mobile M - 375px

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

