### PR TITLE
added instuctions to create a firebase project and app in client readme

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -24,6 +24,7 @@ The client directory is organized into several main directories and components:
     /components     # Reusable React components
     /routes         # Frontend route definitions
 ```
+
 assets: This directory contains static assets such as images, fonts, and other files used in your application's user interface.
 
 components: Reusable React components are stored here. These components can be used throughout your application to maintain consistency and modularity.
@@ -31,7 +32,9 @@ components: Reusable React components are stored here. These components can be u
 routes: Frontend route definitions are defined in this directory. It specifies how different URLs map to specific components and views.
 
 ## Getting Started
+
 # Prerequisites
+
 Before you begin, ensure you have the following prerequisites installed:
 
 - Node.js and npm
@@ -39,20 +42,25 @@ Before you begin, ensure you have the following prerequisites installed:
 # Installation
 
 - Clone the repository:
+
 ```bash
 git clone https://github.com/digitomize/digitomize.git
 ```
+
 - Navigate to the client directory:
+
 ```bash
 cd digitomize/client
 ```
+
 - Install dependencies:
+
 ```bash
 npm install
 ```
 
-
 # Configuration
+
 Create a .env file in the client directory to configure any environment-specific variables or settings that your client application may require. For example, you may need to specify API endpoints or other configuration options.
 
 ```bash
@@ -66,17 +74,37 @@ VITE_REACT_APP_MESSAGING_SENDER_ID=
 VITE_REACT_APP_APP_ID=
 VITE_REACT_APP_MEASUREMENT_ID=
 ```
+
 _Fill the empty fields by creating a demo firebase project._
 
+#### Creating New firebase project and setting up .env variables
+
+* go to [https://firebase.google.com/](Firebase)
+* Create an account if you don't have one and click on get started
+* Add a project
+* Add an app and select web as the platform
+* Once you register your app you'll get a prompt to add firebase SDK to your app
+* In that propt you'll see a const variable called firebaseConfig which will contain all your config info it will look something like this. (these are just dummy values)
+
+  ```json
+  const firebaseConfig = {  apiKey: "IKNdsaKsdabdGL5iuywrfHUIKBubkjbJGDfIBHUGnkjVA",  authDomain: "sample-u78nb.firebaseapp.com",  projectId: "sample-u78nb",  storageBucket: "sample-u78nb.appspot.com",  messagingSenderId: "872459742932",  appId: "9:872459742932:web:&8ufnhjbhbj89nu8b",  measurementId: "G-YTUTY89kFT"};
+  ```
+* Use these values to populate your .env file
+
 # Usage
+
 The client-side codebase is responsible for rendering the user interface and interacting with the backend API. To run the client application, use the following command:
+
 ```bash
 npm run dev
 ```
+
 This command will start the development server. You can then access and interact with the Digitomize client application.
 
 ## Contributing
+
 Contributions to the Digitomize project are welcome! If you would like to contribute to the client-side codebase, please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for details on how to contribute.
 
 ## License
+
 This project is licensed under the [MIT License](../LICENSE).


### PR DESCRIPTION
There was no proper instructions on how to populate the environment variables in .env using firebase for the client. It becomes inconvenience for people who are not familiar with firebase to figure this out and thus creating a poor developer experience.

I fixed this issue by adding instructions in the readme file for client on how to create a firebase project and get the required configurations