### PR TITLE
added the MUI BreadCrumbs Navigations to individual contest card on the desktop view of the website

### DIFF
--- a/client/src/components/IndividualCard.jsx
+++ b/client/src/components/IndividualCard.jsx
@@ -205,6 +205,28 @@ function IndividualCard() {
         )
         :
         (<>
+          <div className="card_Navigation flex justify-center mt-10 text-2xl" >
+                <div className="card_nav_path">
+                  <Link to="/">
+                    <HomeIcon sx={{ mr: 0.5 }} fontSize="inherit" />
+                    Home
+                  </Link>
+                </div>
+                <h3>&gt;</h3>
+                <div className="card_nav_path">
+                  <Link to="/contests">
+                    <WhatshotIcon sx={{ mr: 0.5 }} fontSize="inherit" />
+                    Contests
+                  </Link>
+                </div>
+                <h3>&gt;</h3>
+                <div className="card_nav_path">
+                  <h3>
+                    <GrainIcon sx={{ mr: 0.5 }} fontSize="inherit" />
+                    {name}
+                  </h3>
+              </div>
+            </div>
           <div className="ic py-8" key={vanity} style={{ backgroundColor: colorTheme }}>
             <div className="ic-child">
               <div className='date' style={{ color: 'black', fontWeight: 'bold', backgroundColor: colorTheme }}>{startDate.getDate()} {monthName}' {startDate.getFullYear()}</div>

--- a/client/src/components/IndividualCard.jsx
+++ b/client/src/components/IndividualCard.jsx
@@ -205,7 +205,7 @@ function IndividualCard() {
         )
         :
         (<>
-          <div className="card_Navigation flex justify-center mt-10 text-2xl" >
+          <div className="card_Navigation flex justify-center mt-8 text-2xl" >
                 <div className="card_nav_path">
                   <Link to="/">
                     <HomeIcon sx={{ mr: 0.5 }} fontSize="inherit" />


### PR DESCRIPTION
FIXES ISSUE #277 

It looks Something Link this :- 


<img width="1680" alt="Screenshot 2023-11-27 at 11 39 39 PM" src="https://github.com/digitomize/digitomize/assets/97348386/60d1f515-3b49-4063-a945-201c648d21df">
