### PR TITLE
write example .env files for reference

### DIFF
--- a/backend/.example.env
+++ b/backend/.example.env
@@ -1,0 +1,23 @@
+TEST=Env file connected.
+MONGODB_URL=mongodb://localhost:27017/digitomize
+PORT=4001
+BACKEND_URL=http://localhost:4001
+CONTESTS=true
+USERS=true
+NODE_ENV=development
+
+# Firebase Configuration Json File Format Paste copy copy to to .env file with your firebase credentials 
+# Check /client/READEME.md for setting up firebase and /backend/README.md for setting up firebase admin sdk
+FIREBASE_CREDENTIALS={
+  "type": 
+  "project_id": 
+  "private_key_id": 
+  "private_key":
+  "client_email":
+  "client_id":
+  "auth_uri": 
+  "token_uri":
+  "auth_provider_x509_cert_url": 
+  "client_x509_cert_url": 
+  "universe_domain": 
+}

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,17 +4,15 @@ Welcome to the backend documentation for our open-source project. This document 
 
 ## Table of Contents
 
-- [Backend Documentation](#backend-documentation)
-  - [Table of Contents](#table-of-contents)
-  - [Folder Structure](#folder-structure)
-  - [Getting Started](#getting-started)
-    - [Installation](#installation)
-    - [Environment Variables](#environment-variables)
-      - [Example:](#example)
-  - [Creating a .env from the .example.env file template](#creating-a-env-from-the-exampleenv-file-template)
-  - [Firebase Credentials](#firebase-credentials)
-    - [Running the Server](#running-the-server)
-  - [API Routes](#api-routes)
+- [Folder Structure](#folder-structure)
+- [Getting Started](#getting-started)
+  - [Installation](#installation)
+  - [Environment Variables](#environment-variables)
+    - [Example:](#example)
+- [Creating a .env from the .example.env file template](#creating-a-env-from-the-exampleenv-file-template)
+- [Firebase Credentials](#firebase-credentials)
+  - [Running the Server](#running-the-server)
+- [API Routes](#api-routes)
 
 ## Folder Structure
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,15 +4,17 @@ Welcome to the backend documentation for our open-source project. This document 
 
 ## Table of Contents
 
-- [Folder Structure](#folder-structure)
-- [Getting Started](#getting-started)
-  - [Installation](#installation)
-  - [Environment Variables](#environment-variables)
-  - [Running the Server](#running-the-server)
-- [API Routes](#api-routes)
-- [Contributing](../CONTRIBUTING.md)
-- [Code of Conduct](../CODE_OF_CONDUCT.md)
-- [License](../LICENSE)
+- [Backend Documentation](#backend-documentation)
+  - [Table of Contents](#table-of-contents)
+  - [Folder Structure](#folder-structure)
+  - [Getting Started](#getting-started)
+    - [Installation](#installation)
+    - [Environment Variables](#environment-variables)
+      - [Example:](#example)
+  - [Creating a .env from the .example.env file template](#creating-a-env-from-the-exampleenv-file-template)
+  - [Firebase Credentials](#firebase-credentials)
+    - [Running the Server](#running-the-server)
+  - [API Routes](#api-routes)
 
 ## Folder Structure
 
@@ -59,6 +61,12 @@ NODE_ENV=development
 # Firebase Configuration
 FIREBASE_CREDENTIALS= # you need to add JSON for this
 ```
+## Creating a .env from the .example.env file template
+
+- Create a new .env file in the backend directory
+- Copy the contents of the .example.env in the the backend directory and paste them into your created .env file
+- Fill in the FIREBASE_CREDENTIALS= variable in JSON with the JSON credentials generated from your created firebase project (see below for instructions on how to get these credentials)
+
 
 ## Firebase Credentials
 

--- a/client/.example.env
+++ b/client/.example.env
@@ -1,0 +1,9 @@
+VITE_REACT_APP_BACKEND_URL=http://localhost:4001
+VITE_REACT_APP_FRONTEND_URL=http://localhost:5173
+VITE_REACT_APP_API_KEY=firebase_api_key
+VITE_REACT_APP_AUTH_DOMAIN=firebase_auth_domain
+VITE_REACT_APP_PROJECT_ID=firebase_project_id
+VITE_REACT_APP_STORAGE_BUCKET=firebase_storage_bucket
+VITE_REACT_APP_MESSAGING_SENDER_ID=firebase_sender_id
+VITE_REACT_APP_APP_ID=firebase_app_id
+VITE_REACT_APP_MEASUREMENT_ID=firebase_app_measurement_id

--- a/client/README.md
+++ b/client/README.md
@@ -4,14 +4,18 @@ Welcome to the client-side documentation for Digitomize, an open-source platform
 
 ## Table of Contents
 
-- [Project Structure](#project-structure)
-- [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-  - [Configuration](#configuration)
+- [Digitomize - Client](#digitomize---client)
+  - [Table of Contents](#table-of-contents)
+  - [Project Structure](#project-structure)
+  - [Getting Started](#getting-started)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Configuration](#configuration)
+  - [Creating a .env from the .example.env file template](#creating-a-env-from-the-exampleenv-file-template)
+      - [Creating New firebase project and setting up .env variables](#creating-new-firebase-project-and-setting-up-env-variables)
 - [Usage](#usage)
-- [Contributing](#contributing)
-- [License](#license)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Project Structure
 
@@ -74,8 +78,13 @@ VITE_REACT_APP_MESSAGING_SENDER_ID=
 VITE_REACT_APP_APP_ID=
 VITE_REACT_APP_MEASUREMENT_ID=
 ```
-
 _Fill the empty fields by creating a demo firebase project._
+
+## Creating a .env from the .example.env file template
+
+- Create a new .env file in the client directory
+- Copy the .example.env in the the client directory and paste it's contents into your created .env file
+- Fill in the empty fields with the values from your firebase project (see below for instructions on how to create a firebase project)
 
 #### Creating New firebase project and setting up .env variables
 

--- a/client/README.md
+++ b/client/README.md
@@ -4,10 +4,8 @@ Welcome to the client-side documentation for Digitomize, an open-source platform
 
 ## Table of Contents
 
-- [Digitomize - Client](#digitomize---client)
-  - [Table of Contents](#table-of-contents)
-  - [Project Structure](#project-structure)
-  - [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Configuration](#configuration)


### PR DESCRIPTION
I added .example.env files for the frontend and backend to the code base so devs can genereate their firebase credentials, create the .env files, and work on the code as quickly as possible