### PR TITLE
Platform username link 

### DIFF
--- a/client/src/user/Profile/components/PlatformRatings.jsx
+++ b/client/src/user/Profile/components/PlatformRatings.jsx
@@ -95,7 +95,14 @@ function PlatformRatings() {
             </figure>
             <div className="card-body p-4 text-center items-center w-full">
               <h2 className="card-title text-center my-3 cursor-pointer">
-                @{platformData?.username || "user not found"}
+                <a href={platformData?.username
+                      ? contestLinks[platform].profileUrl +
+                        platformData.username
+                      : "#"
+                      }
+                      target={platformData?.username ? "_blank" : ""}
+                      rel="noopener noreferrer"
+                      >@{platformData?.username || "user not found"}</a> 
                 <a
                   href={
                     platformData?.username


### PR DESCRIPTION
Fixes #330 
Now on clicking the username, user is redirected to the platform page.
