### PR TITLE
Fix- NavBar.JSX's contests active styling fix

### DIFF
--- a/client/src/components/NewNavbar.jsx
+++ b/client/src/components/NewNavbar.jsx
@@ -27,7 +27,7 @@ export default function NewNavbar({ position }) {
     },
     {
       title: "Contests",
-      path: "/contests#list",
+      path: "/contests",
     },
     {
       title: "About",

--- a/client/src/components/globals/NewNavbar.jsx
+++ b/client/src/components/globals/NewNavbar.jsx
@@ -27,7 +27,7 @@ export default function NewNavbar({ position }) {
     },
     {
       title: "Contests",
-      path: "/contests#list",
+      path: "/contests",
     },
     {
       title: "About",


### PR DESCRIPTION
Before-
![image](https://github.com/digitomize/digitomize/assets/97522955/c23b87d4-a1a9-448d-aa18-21f75f66c7f7)
Now-
![image](https://github.com/digitomize/digitomize/assets/97522955/85cdae82-fd29-4588-984c-8b4659beb5d5)


Fixed a bug where when the contests page is active, the style of **contests** in navigation bar doesn't changes
