### PR TITLE
add rounded corners on highlighted text

### DIFF
--- a/client/src/components/Home/SectionOne.jsx
+++ b/client/src/components/Home/SectionOne.jsx
@@ -19,7 +19,7 @@ export default function SectionOne() {
         <h1 className="mt-2 text-white max-md:text-4xl md:text-7xl">
           <span>One place for all your</span>
           <span className="block mt-1 md:mt-6 relative">
-            <span className="bg-digitomize-bg px-2 relative">
+            <span className="bg-digitomize-bg px-2 relative rounded-md">
               <span className="relative z-10">
                 {/* <img src={santaHat} className="absolute -rotate-45 transform h-16 w-16 -left-2 top-[-10%]" alt="Santa Hat" /> */}
                 coding platforms

--- a/client/src/user/leaderboard/Leaderboard.jsx
+++ b/client/src/user/leaderboard/Leaderboard.jsx
@@ -220,7 +220,7 @@ export default function Leaderboard() {
           One Scoreboard for
           <br />
           All Your{" "}
-          <span className="bg-[#1584FF] py-[1px] sm:py-1">
+          <span className="bg-[#1584FF] py-[1px] sm:py-1 rounded-md">
             &nbsp;Coding Battles&nbsp;
           </span>
         </h1>


### PR DESCRIPTION
Issue#402

Fix a bug in the home and leaderboard page where the highlighted texts (coding platforms & Coding Battles) isn't rounded like all the others


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated text styling to include rounded edges in the Home and Leaderboard sections for a more polished visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->