### PR TITLE
Fix #402, Highlight rounding in /home and /leaderboard

### DIFF
--- a/client/src/components/Home/SectionOne.jsx
+++ b/client/src/components/Home/SectionOne.jsx
@@ -19,7 +19,7 @@ export default function SectionOne() {
         <h1 className="mt-2 text-white max-md:text-4xl md:text-7xl">
           <span>One place for all your</span>
           <span className="block mt-1 md:mt-6 relative">
-            <span className="bg-digitomize-bg px-2 relative">
+            <span className="bg-digitomize-bg px-3 rounded-full relative">
               <span className="relative z-10">
                 {/* <img src={santaHat} className="absolute -rotate-45 transform h-16 w-16 -left-2 top-[-10%]" alt="Santa Hat" /> */}
                 coding platforms

--- a/client/src/user/leaderboard/Leaderboard.jsx
+++ b/client/src/user/leaderboard/Leaderboard.jsx
@@ -220,7 +220,7 @@ export default function Leaderboard() {
           One Scoreboard for
           <br />
           All Your{" "}
-          <span className="bg-[#1584FF] py-[1px] sm:py-1">
+          <span className="bg-[#1584FF] rounded-full py-[1px] sm:py-1">
             &nbsp;Coding Battles&nbsp;
           </span>
         </h1>


### PR DESCRIPTION
just add class "rounded-full" and change px-2 to px-3 in the parent of that span where parent contain the class "bg-digitomize-bg"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated text elements with rounded styling for a more polished and modern visual presentation in the Home and Leaderboard sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->