### PR TITLE
Update Original Logo of MELTCD in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <a href="https://m.do.co/c/db7dbc698e16" target="_blank"><img align="center" src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/PoweredByDO/DO_Powered_by_Badge_blue.svg" alt="DigitalOcean Logo" height="150" width="180"></a> 
 <img align="center" src="https://github.com/digitomize/digitomize/assets/76090263/efd3da13-2571-4ae2-b399-554df138190f" alt="GitBook Logo" height="auto" width="180">
 <img align="center" src="https://github.com/krushnarout/digitomize/assets/129386740/3f224853-cf4b-4318-ba27-8285d1c9a0fe" alt="MSME Logo" height="auto" width="180">
-<img align="center" src="https://digitomize.com/assets/meltcd-9b0f5105.png" alt="MELT CD Logo" height="auto" width="180">
+<img align="center" src="https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcROO_yLE47eeYv8eSiT3aMB1AWncngyOzGHYqptZwwckpfmH4m0" alt="MELT CD Logo" height="auto" width="180">
 
 # Table of Contents
 


### PR DESCRIPTION
- Updated the Logo image with original Logo image , as suggested by Pranshu.
- The url used is the google url created from the Repo itself , so it will not break till the logo image is kept in the repo.
fixes #457 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the source URL for the "MELT CD Logo" in the README to a new encrypted link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->