### PR TITLE
Fixed drop-down overlap issue #509   

### DIFF
--- a/client/src/components/globals/NewNavbar.jsx
+++ b/client/src/components/globals/NewNavbar.jsx
@@ -145,7 +145,7 @@ export default function NewNavbar({ position }) {
       <div
         className={`${
           position ? position : "sticky"
-        } inset-x-0 top-0 z-50 pt-10 hidden justify-center md:flex pointer-events-auto w-fit m-auto`}
+        } inset-x-0 top-0 relative z-50 pt-10 hidden justify-center md:flex pointer-events-auto w-fit m-auto`}
         style={{ ...navbarStyle }}
       >
         <div className="flex cursor-pointer items-center gap-4 rounded-full bg-white p-2">
@@ -189,7 +189,7 @@ export default function NewNavbar({ position }) {
                 </a>
                 <ul
                   tabIndex={0}
-                  className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52"
+                  className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52"
                 >
                   {navLinksDashboard.map((navLinkDashboard, index) => (
                     <li key={index}>
@@ -216,6 +216,6 @@ export default function NewNavbar({ position }) {
           </div>
         </div>
       </div>
-    </>
-  );
+</>
+);
 }


### PR DESCRIPTION
Fixed drop-down overlap issue (Fixes #509) 

## Summary 
Issue was in the  z-index of parent component which was not being applied because position was not speicified. Added position relative.
Here's the view after fix:
![image](https://github.com/digitomize/digitomize/assets/58481032/803b0921-d55f-4dd6-be10-1c385bfe9cf4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the layout and appearance of the NewNavbar component for improved user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->