### PR TITLE
Implement query based contests

### DIFF
--- a/client/src/components/Contests/Filter.jsx
+++ b/client/src/components/Contests/Filter.jsx
@@ -88,6 +88,25 @@ function Filter() {
       })
       .catch((error) => console.error("Error fetching data:", error));
   }, [selectedPlatforms]);
+  useEffect(() => {
+    // Fetch query params from url
+    const params = new URLSearchParams(window.location.search);
+    let platformsFromQuery = params.get("platform");
+
+    // Split the query params into array and setSelectedPlatforms
+    if (platformsFromQuery) {
+      platformsFromQuery = platformsFromQuery.split(",");
+
+      // Select only the valid platforms
+      const validPlatforms = platformsFromQuery.filter((platform) =>
+        platforms.includes(platform),
+      );
+
+      if (validPlatforms) {
+        setSelectedPlatforms(validPlatforms);
+      }
+    }
+  }, []);
 
   const handleDelete = (value) => {
     let newSelectedParams = selectedPlatforms.filter(


### PR DESCRIPTION
fixes [#510](https://github.com/digitomize/digitomize/issues/510)

Change log:
- The search will now be auto-populated with the platform names passed in the query params.
- The code also checks if the platform names are valid or not. (For example, ?platform=codechef,abs,leetci) will only include codechef in the search params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Contests filter with the ability to read and apply platform filters directly from the URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->