### PR TITLE
Fix #601 : remove 'forgot-password' on signup

### DIFF
--- a/client/src/components/globals/Signup.jsx
+++ b/client/src/components/globals/Signup.jsx
@@ -203,13 +203,6 @@ export default function Signup() {
                           />
                         ))}
                     </div>
-                    <label className="label">
-                      <span className="label-text-alt"></span>
-                      <Link to="/forgot-password" >
-                        <span className="label-text-alt text-custom-blue">forgot password?</span>
-                      </Link>
-
-                    </label>
                   </div>
                 </div>
                 <div className="items-center">


### PR DESCRIPTION
Hello,
Hope you're doing well.
As it has been requested in the issue #601, I have made changes in the Signup.jsx file.
I simply removed the label tag which had the link to forget-password route.
I tested this by configuring a firebase project and generating .env file in the client directory.
Now, the signup page looks something like this:

![image](https://github.com/digitomize/digitomize/assets/31406633/7361a452-4bcd-49c6-9ef7-6bc1751a74c2)

Hope these code changes help in meeting the requirement.
If at all there are any changes required then do let me know.
Sincere apologies if I have made any mistakes while implementing the same.

Thanks,
Mohit Kambli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the "forgot password?" link from the signup page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->