### PR TITLE
feat: add reviewer assign github action workflow

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+addReviewers: true
+
+addAssignees: false
+
+reviewers:
+  - pranshugupta54
+
+numberOfReviewers: 1

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,12 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: ".github/auto_assign.yml"


### PR DESCRIPTION
### Related issue:
This PR closes issue #739  


### Description:
This pull request addresses the need for a GitHub Actions workflow that automates the process of assigning reviewers to pull requests upon their opening. 

### Files added
- `.github/workflows/action.yml`
- `.github/auto_assign.yml`

### Proposed Changes:
1. **Workflow Development:** Introduce a GitHub Actions workflow script that triggers upon the opening of a pull request.
   
2. **Reviewer Assignment Logic:** Implement logic to automatically assign reviewers based on predefined rules or configurations defined in the workflow config.

### Expected Behavior:
- The workflow triggers automatically when a pull request is opened.
- Reviewers are assigned to the pull request based on the defined rules or configurations.
- Reviewer assignments are customizable and adaptable to project-specific requirements.

### Benefits:
- Streamlines the code review process by automating reviewer assignments.
- Ensures timely feedback and reduces bottlenecks in the development workflow.
- Improves collaboration and accountability among team members.

### Checklist:
- [X] Implemented GitHub Actions workflow for automated reviewer assignment.
- [X] Tested the workflow to ensure proper triggering and reviewer assignment.

@pranshugupta54 please review this PR and don't forget to add SWOC and difficulty level label after merging the PR.
Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented automation to streamline the review process by automatically assigning reviewers to pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->