### PR TITLE
fix: update all mongodb URLs to use 127.0.0.1 instead of localhost

### DIFF
--- a/backend/.example.env
+++ b/backend/.example.env
@@ -1,5 +1,5 @@
 TEST=Env file connected.
-MONGODB_URL=mongodb://localhost:27017/digitomize
+MONGODB_URL=mongodb://127.0.0.1:27017/digitomize
 PORT=4001
 BACKEND_URL=http://localhost:4001
 CONTESTS=true

--- a/backend/README.md
+++ b/backend/README.md
@@ -96,7 +96,7 @@ Configure your environment variables in the `.env` file. This file should contai
 
 ```bash
 TEST=Env file connected.
-MONGODB_URL=mongodb://localhost:27017/digitomize
+MONGODB_URL=mongodb://127.0.0.1:27017/digitomize
 PORT=4001
 BACKEND_URL=http://localhost:4001
 CONTESTS=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - "4001:4001"
     environment:
-      - MONGODB_URL=mongodb://localhost:27017/digitomize
+      - MONGODB_URL=mongodb://127.0.0.1:27017/digitomize
       - PORT=4001
       - BACKEND_URL=http://localhost:4001
       - CONTESTS=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated MongoDB URL details in backend setup instructions to enhance clarity and consistency across documentation and configuration files.

- **Chores**
	- Standardized the MongoDB connection string across various configuration files to ensure uniform access settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->