### PR TITLE
fix: usernames must start with a letter

### DIFF
--- a/client/src/components/globals/Signup.jsx
+++ b/client/src/components/globals/Signup.jsx
@@ -150,8 +150,8 @@ export default function Signup() {
                       className="input input-bordered w-full bg-black border-2 border-jet"
                       onChange={(e) => usernameRef.current=e.target.value}
                       required
-                      pattern="^\S*$"
-                      title="no whitespaces allowed"
+                      pattern="^[a-zA-Z]\S*$"
+                      title="No whitespaces allowed. Must start with a character"
                     />
                   </div>
                   <div className="w-full px-3">

--- a/client/src/components/globals/Signup.jsx
+++ b/client/src/components/globals/Signup.jsx
@@ -151,7 +151,7 @@ export default function Signup() {
                       onChange={(e) => usernameRef.current=e.target.value}
                       required
                       pattern="^[a-zA-Z]\S*$"
-                      title="No whitespaces allowed. Must start with a character"
+                      title="Username must start with a letter and contain no spaces (e.g., JohnDoe123)"
                     />
                   </div>
                   <div className="w-full px-3">


### PR DESCRIPTION
The username must not start with a number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the signup input validation to require starting with a letter and disallowing whitespaces, improving data quality and user input consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->