### PR TITLE
fix: Fixed Dashboard Styling Issue

### DIFF
--- a/client/src/user/Profile/components/UserCard.jsx
+++ b/client/src/user/Profile/components/UserCard.jsx
@@ -92,11 +92,11 @@ function UserCard({
       </div>
       <div className="mt-6 sm:hidden">
         {skills.length > 0 && <p className="text-[16px]">Skills</p>}
-        <div className="flex flex-row mt-3">
+        <div className="flex flex-wrap mt-3">
           {skills.map((skill, index) => (
             <div
               key={index}
-              className=" bg-[#1582ffb3] bg-opacity-80 text-[#1582FF] text-[12px] px-3 py-[2px] rounded-[12px] font-[500] mr-4"
+              className=" bg-[#1582ffb3] bg-opacity-80 text-[#1582FF] text-[12px] px-3 py-[2px] rounded-[12px] font-[500] mr-4 mb-1"
             >
               {skill}
             </div>
@@ -144,11 +144,11 @@ function UserCard({
       </div>
       <div className="mt-6 max-sm:hidden">
         {skills.length > 0 && <p className="text-[16px]">Skills</p>}
-        <div className="flex flex-row mt-3">
+        <div className="flex flex-wrap mt-3">
           {skills.map((skill, index) => (
             <div
               key={index}
-              className="bg-custom-blue bg-opacity-80 text-black text-[12px] px-3 py-[2px] rounded-[12px] font-[500] mr-4"
+              className="bg-custom-blue bg-opacity-80 text-black text-[12px] px-3 py-[2px] rounded-[12px] font-[500] mr-4 mb-1"
             >
               {skill}
             </div>


### PR DESCRIPTION
FIXES #839
This PR fixes the issue where Skills were not wrapping inside the div in the UserCard displayed on the dashboard.

Screenshots:
![image](https://github.com/digitomize/digitomize/assets/153297759/504e6650-39c9-4d60-be36-bb6cb503a201)
![image](https://github.com/digitomize/digitomize/assets/153297759/a4711a8e-2b3e-4ac4-8587-8be7aa1286bb)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the display of skills in user profiles for better spacing and readability. Skills now wrap appropriately in limited horizontal space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->