### PR TITLE
feat: Re-designed Supported-by Section

### DIFF
--- a/client/src/components/Home/SectionOne.jsx
+++ b/client/src/components/Home/SectionOne.jsx
@@ -14,6 +14,7 @@ import microsoft from "./svgs/microsoft4strp.svg";
 import { cn } from "../../lib/utils";
 import AnimatedGradientText from "../../components/magicui/animated-gradient-text";
 import { ChevronRight } from "lucide-react";
+import Marquee from "react-fast-marquee";
 
 export default function SectionOne() {
 
@@ -142,7 +143,8 @@ export default function SectionOne() {
         <span>
           <p className="text-lg text-powered">Supported By</p>
         </span>
-        <span className="flex flex-row flex-wrap gap-4 items-center justify-center">
+        <Marquee gradient gradientColor="#06090E" pauseOnHover className="max-w-xl md:max-w-2xl lg:max-w-3xl">
+        <span className="flex flex-row flex-wrap gap-4 px-2 items-center justify-center">
           <a href="https://m.do.co/c/db7dbc698e16">
             <img
               className="max-md:w-36 md:w-44"
@@ -184,6 +186,7 @@ export default function SectionOne() {
           />
         </a>
         </span>
+        </Marquee>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Pull Request Details
This PR adds infinite scroll animations to Supported-by Section on the homepage.

### Description

A Marquee tag has been added to introduce the infinite scroll with gradient. The width also changes with different screen sizes to maintain same gap between the elements.

### Fixes

Fixes #902 

### Type of PR

- [X] Feature enhancement

### Screenshots (if applicable)

https://github.com/digitomize/digitomize/assets/153297759/642a7f0d-057d-496c-844f-c5d1672fc254

### Checklist

- [X] I have read and followed the [Pull Requests and Issues guidelines](https://github.com/digitomize/digitomize/blob/main/PR_GUIDELINES.md#pull-requests-and-issues).
- [ ] The code has been properly linted and formatted using `npm run lint:fix` and `npm run format:fix`.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, snapshots, and videos after making the changes.
- [X] I have not borrowed code without disclosing it, if applicable.
- [X] This pull request is not a Work In Progress (WIP), and only completed and tested changes are included.
- [X] I have tested these changes locally.
- [X] My code follows the project's style guidelines.
- [ ] I have updated the documentation accordingly.
- [ ] This PR has a corresponding issue in the issue tracker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a scrolling marquee effect to the content in the homepage section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->