### PR TITLE
feat: backend for challenges

### DIFF
--- a/backend/challenges/controllers/challengeController.js
+++ b/backend/challenges/controllers/challengeController.js
@@ -1,0 +1,37 @@
+import { AllChallenge } from "../models/challenge.js";
+
+let allChallengeList = []; // Variable to store challenges in memory
+
+// Function to fetch challenges from MongoDB and update the allChallengeList variable
+
+async function updateChallenges () {
+  try {
+    console.log("┌──────────────────────────────────┐");
+    console.log("│ Retrieving Data | MongoDB to App".padEnd(35) + "│");
+    console.log("└──────────────────────────────────┘");
+
+    // Fetch challenges from MongoDB (without id, createdAt and updatedAt)
+    const fetchedChallenges = await AllChallenge.find().select(
+      "-_id -createdAt -updatedAt -__v",
+    );
+
+    // Sorting challenges
+    fetchedChallenges.sort((a, b) => a.startTimeUnix - b.startTimeUnix);
+
+    // Update the allChallengeList variable
+    allChallengeList = fetchedChallenges;
+
+    console.log("===============================================");
+    console.log("Challenges variable updated successfully. | MongoDb to App");
+    console.log("===============================================");
+  } catch (error) {
+    console.error("Error fetching challenges:", error);
+  }
+}
+
+// Function to return allChallengeList
+async function getChallengeList () {
+  return await allChallengeList;
+}
+
+export { updateChallenges, getChallengeList };

--- a/backend/challenges/controllers/challengeController.js
+++ b/backend/challenges/controllers/challengeController.js
@@ -21,9 +21,7 @@ async function updateChallenges () {
     // Update the allChallengeList variable
     allChallengeList = fetchedChallenges;
 
-    console.log("===============================================");
-    console.log("Challenges variable updated successfully. | MongoDb to App");
-    console.log("===============================================");
+    console.info("Challenges updated: %d items", fetchedChallenges.length);
   } catch (error) {
     console.error("Error fetching challenges:", error);
   }

--- a/backend/challenges/controllers/challengeDbSyncController.js
+++ b/backend/challenges/controllers/challengeDbSyncController.js
@@ -42,7 +42,7 @@ async function syncChallenges () {
     await addToDB(challenges);
     console.log("└────────────────────────────────────────────────────┘");
   } catch (err) {
-    console.log("Error syncing challenges:", err);
+    console.log("Error occurred during challenge synchronization:", err);
   }
 }
 

--- a/backend/challenges/controllers/challengeDbSyncController.js
+++ b/backend/challenges/controllers/challengeDbSyncController.js
@@ -1,0 +1,49 @@
+import { AllChallenge } from "../models/challenge.js";
+import dotenv from "dotenv";
+import { quineQuest_c } from "./platforms/quinequestController.js";
+
+dotenv.config({ path: "../../.env" });
+
+async function clearCompletedChallenge () {
+  try {
+    const currentTime = Math.floor(Date.now() / 1000);
+    await AllChallenge.deleteMany({ endTimeUnix: { $lt: currentTime } });
+    console.log("Deleted challenges which have end time before now.");
+  } catch (err) {
+    console.log("Error while deleting completed challenges:", err);
+  }
+}
+
+async function addToDB (challenges) {
+  try {
+    await AllChallenge.insertMany(challenges, { ordered: false });
+    console.log("Challenges added to MongoDB");
+  } catch (err) {
+    if (err.code === 11000) {
+      console.log("│ Some duplicate(s) in AllChallenge for Quine".padEnd(53) + "│");
+    } else {
+      console.log("Error adding challenges to MongoDB:", err);
+    }
+  }
+}
+
+async function syncChallenges () {
+  try {
+    console.log("===============================================");
+    console.log("Syncing Data | API to MongoDB");
+    console.log("===============================================");
+
+    await clearCompletedChallenge();
+
+    const challenges = [];
+
+    console.log("┌───────────────────────Quine────────────────────────┐");
+    challenges.push(await quineQuest_c());
+    await addToDB(challenges);
+    console.log("└────────────────────────────────────────────────────┘");
+  } catch (err) {
+    console.log("Error syncing challenges:", err);
+  }
+}
+
+export { syncChallenges };

--- a/backend/challenges/controllers/challengeDbSyncController.js
+++ b/backend/challenges/controllers/challengeDbSyncController.js
@@ -10,7 +10,7 @@ async function clearCompletedChallenge () {
     await AllChallenge.deleteMany({ endTimeUnix: { $lt: currentTime } });
     console.log("Deleted challenges which have end time before now.");
   } catch (err) {
-    console.log("Error while deleting completed challenges:", err);
+    console.log(`Error while deleting completed challenges before ${currentTime}:`, err);
   }
 }
 

--- a/backend/challenges/controllers/platforms/quinequestController.js
+++ b/backend/challenges/controllers/platforms/quinequestController.js
@@ -1,6 +1,7 @@
 import axios from "axios";
-async function fetchChallenge () {
-  // this data is needed for the PUT request it can be random
+
+async function quineQuest_c () {
+  // this data is needed for the PUT request ,it can be random
   const data = {
     user_id: "100",
     page: "1",
@@ -26,4 +27,4 @@ async function fetchChallenge () {
   }
 }
 
-fetchChallenge();
+export { quineQuest_c };

--- a/backend/challenges/controllers/platforms/quinequestController.js
+++ b/backend/challenges/controllers/platforms/quinequestController.js
@@ -22,9 +22,10 @@ async function quineQuest_c () {
     };
     return formattedChallenge;
   } catch (error) {
-    console.log(error);
+    console.error("Failed to fetch data from Quine Quest:", error.response || error.message);
     return null;
   }
+}
 }
 
 export { quineQuest_c };

--- a/backend/challenges/controllers/platforms/quinequestController.js
+++ b/backend/challenges/controllers/platforms/quinequestController.js
@@ -1,0 +1,29 @@
+import axios from "axios";
+async function fetchChallenge () {
+  // this data is needed for the PUT request it can be random
+  const data = {
+    user_id: "100",
+    page: "1",
+  };
+  try {
+    const response = await axios.put("https://cosmos.quine.sh/api/cosmos/creators/quest/", data);
+    const challengeData = response.data;
+    const startUnix = Math.floor(new Date(challengeData.creator_quest_started_at).getTime() / 1000);
+    const endTime = Math.floor(new Date(challengeData.creator_quest_ends_at).getTime() / 1000);
+    const formattedChallenge = {
+      host: "quine",
+      name: challengeData.creator_quest_name,
+      vanity: challengeData.creator_quest_id,
+      url: "https://quine.sh/quests/creator/submissions",
+      description: challengeData.creator_quest_short_description,
+      startTimeUnix: startUnix,
+      endTimeUnix: endTime,
+    };
+    return formattedChallenge;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+}
+
+fetchChallenge();

--- a/backend/challenges/controllers/platforms/quinequestController.js
+++ b/backend/challenges/controllers/platforms/quinequestController.js
@@ -26,6 +26,5 @@ async function quineQuest_c () {
     return null;
   }
 }
-}
 
 export { quineQuest_c };

--- a/backend/challenges/models/challenge.js
+++ b/backend/challenges/models/challenge.js
@@ -38,6 +38,6 @@ const challengeSchema = new mongoose.Schema(
   },
 );
 
-const AllChallenge = mongoose.model("AllChallenge",challengeSchema, "allchallenges");
+const AllChallenge = mongoose.model("AllChallenge", challengeSchema, "allchallenges");
 
 export { AllChallenge };

--- a/backend/challenges/models/challenge.js
+++ b/backend/challenges/models/challenge.js
@@ -1,0 +1,43 @@
+import mongoose from "mongoose";
+
+// Challenge Schema
+
+const challengeSchema = new mongoose.Schema(
+  {
+    host: {
+      type: String,
+      lowercase: true,
+      required: [true, "Host is required."],
+    },
+    name: {
+      type: String,
+      required: [true, "Name is required."],
+    },
+    vanity: {
+      type: String,
+      required: [true, "Vanity is required."],
+      lowercase: true,
+    },
+    url: {
+      type: String,
+      required: [true, "URL is required."],
+      unique: true,
+    },
+    description: {
+      type: String,
+      required: [true, "Description is required."],
+    },
+    startTimeUnix: {
+      type: Number,
+      required: [true, "Start time is required."],
+    },
+    endTimeUnix: {
+      type: Number,
+      required: [true, "End time is required."],
+    },
+  },
+);
+
+const AllChallenge = mongoose.model("AllChallenge",challengeSchema, "allchallenges");
+
+export { AllChallenge };

--- a/backend/challenges/models/challenge.js
+++ b/backend/challenges/models/challenge.js
@@ -7,33 +7,33 @@ const challengeSchema = new mongoose.Schema(
     host: {
       type: String,
       lowercase: true,
-      required: [true, "Host is required."],
+      required: [true, "Please provide the host of the challenge."],
     },
     name: {
       type: String,
       unique: true,
-      required: [true, "Name is required."],
+      required: [true, "Please provide the name of the challenge."],
     },
     vanity: {
       type: String,
-      required: [true, "Vanity is required."],
+      required: [true, "Please provide the vanity of the challenge."],
       lowercase: true,
     },
     url: {
       type: String,
-      required: [true, "URL is required."],
+      required: [true, "Please provide the URL of the challenge."],
     },
     description: {
       type: String,
-      required: [true, "Description is required."],
+      required: [true, "Please provide a description of the challenge."],
     },
     startTimeUnix: {
       type: Number,
-      required: [true, "Start time is required."],
+      required: [true, "Please provide the start time of the challenge."],
     },
     endTimeUnix: {
       type: Number,
-      required: [true, "End time is required."],
+      required: [true, "Please provide the end time of the challenge."],
     },
   },
 );

--- a/backend/challenges/models/challenge.js
+++ b/backend/challenges/models/challenge.js
@@ -11,6 +11,7 @@ const challengeSchema = new mongoose.Schema(
     },
     name: {
       type: String,
+      unique: true,
       required: [true, "Name is required."],
     },
     vanity: {
@@ -21,7 +22,6 @@ const challengeSchema = new mongoose.Schema(
     url: {
       type: String,
       required: [true, "URL is required."],
-      unique: true,
     },
     description: {
       type: String,

--- a/backend/challenges/routes/challengeRoutes.js
+++ b/backend/challenges/routes/challengeRoutes.js
@@ -1,0 +1,23 @@
+import { Router } from "express";
+
+import { getChallengeList } from "../controllers/challengeController.js";
+const router = Router();
+
+// GET route for challenges
+router.get("/", async (req, res) => {
+  try {
+    const challenges = await getChallengeList();
+    res.status(200).json({
+      total: challenges.length,
+      results: challenges,
+    });
+  } catch (err) {
+    console.log("Error:", err);
+    res.status(500).json({
+      error: "Internal server error",
+      message: "Internal server error",
+    });
+  }
+});
+
+export default router;

--- a/backend/challenges/routes/challengeRoutes.js
+++ b/backend/challenges/routes/challengeRoutes.js
@@ -12,7 +12,7 @@ router.get("/", async (req, res) => {
       results: challenges,
     });
   } catch (err) {
-    console.log("Error:", err);
+    console.error("Error fetching challenges:", err.message);
     res.status(500).json({
       error: "Internal server error",
       message: "Internal server error",

--- a/backend/index.js
+++ b/backend/index.js
@@ -132,6 +132,7 @@ async function startServersProduction() {
     await setupUserServer();
     await setupContestServer();
     await setupHackathonServer();
+    await setupChallengeServer();
 
     // Handle unhandled routes
     app.all("*", (req, res, next) => {
@@ -142,6 +143,7 @@ async function startServersProduction() {
     servers.push("User");
     servers.push("Contest");
     servers.push("Hackathon");
+    servers.push("Challenge")
 
     console.log("┌──────────────────────────────────┐");
     if (servers.length > 0) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,10 @@ import potdRoutes from "./potd/routes/potdRoutes.js";
 import hackathonAPISyncer from "./hackathons/controllers/hackathonApiSyncController.js";
 import hackathonDBSyncer from "./hackathons/controllers/hackathonDbSyncController.js";
 import hackathonRoutes from "./hackathons/routes/hackathonRoutes.js";
+import { updateChallenges } from "./challenges/controllers/challengeController.js";
+import { syncChallenges } from "./challenges/controllers/challengeDbSyncController.js";
+import challengeRoutes from "./challenges/routes/challengeRoutes.js";
+
 
 dotenv.config();
 const app = express();
@@ -107,6 +111,16 @@ async function setupHackathonServer() {
   app.use("/hackathons", hackathonRoutes);
 }
 
+async function setupChallengeServer() {
+  await updateChallenges();
+  setInterval(updateChallenges, 90 * 60 * 1000);
+
+  await syncChallenges();
+  setInterval(syncChallenges, 60 * 60 * 1000);
+
+  app.use("/challenges", challengeRoutes);
+}
+
 async function startServersProduction() {
   try {
     app.use(cors());
@@ -168,6 +182,10 @@ async function startServersDev() {
     if (process.env.HACKATHONS === "true") {
       await setupHackathonServer();
       servers.push("Hackathon");
+    }
+    if (process.env.CHALLENGES === "true") {
+      await setupChallengeServer();
+      servers.push("Challenge");
     }
 
     // Handle unhandled routes


### PR DESCRIPTION
## Pull Request Details

### Description

Implemented backend which fetches challenge from quine quests. according to issue 836

### Type of PR

- [x] Feature enhancement

### Summary

-added controller to fetch challenge from quine using axios
-setup routes and mongoose model for the challenge
-setup index.js to update db and sync regularly for the challenges


### Screenshots (if applicable)

<img width="862" alt="Screenshot 2024-06-11 at 9 24 48 PM" src="https://github.com/digitomize/digitomize/assets/147314019/9b4f1c98-f1d0-4240-82de-cc7a5c3341d7">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to fetch, update, and sync challenges from MongoDB and an external API.
  - Added route for fetching a list of challenges and returning it as JSON.
  - Implemented a MongoDB schema for challenges with necessary fields and validations.

- **Enhancements**
  - Improved error handling for challenge data retrieval and synchronization processes.

- **Integrations**
  - Integrated new functions to update and sync challenges, and set up challenge routes for handling requests in both production and development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->