### PR TITLE
Add active state styling for "Contest" button on subpages under /contest path

### DIFF
--- a/client/src/components/globals/Navbar/NewNavbar.jsx
+++ b/client/src/components/globals/Navbar/NewNavbar.jsx
@@ -165,7 +165,7 @@ export default function NewNavbar({ position }) {
                   to={navLink.path}
                   key={index}
                   className={`px-4 py-2 text-zinc-700 cursor-pointer rounded-full transition ${
-                    location.pathname === navLink.path
+                    location.pathname === navLink.path || (["/challenges","/hackathons","/internships","/jobs"].includes(location.pathname)&&navLink.path==="/contests")
                       ? "bg-zinc-400 text-zinc-950"
                       : ""
                   } hover:bg-zinc-200`}


### PR DESCRIPTION
## Pull Request Details

### Description

This pull request adds an active state to the "Contest" button in the top navigation bar when users are on any page under the `/contest` path (e.g., `/contest`, `/challenges`, `/hackathons`, `/internships`, `/jobs`). 

- The "Contest" button will now change its background and text color to indicate the active state.
- This update improves navigation clarity and enhances the user experience by visually marking the "Contest" section when users are on any related subpage.

### Fixes

#1078 

### Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (specify): ******\_\_\_******

### Summary

This pull request implements active state styling for the "Contest" button in the top navigation bar when navigating to any subpage under the `/contest` path.

- **Changes Summary**:
  - **Updated navigation logic**: The "Contest" button is now highlighted when users are on any page under the `/contest` path (e.g., `/contest`, `/challenges`, `/hackathons`, `/internships`, or `/jobs`).
  - **Added active state styles**: Applied background and text color changes to visually indicate the active state of the "Contest" button when on these subpages.

This improves the user experience by clearly showing users which section of the site they are currently in.

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/180b3fb0-3dfe-43e5-90fd-7ce7b9f311bb)

![image](https://github.com/user-attachments/assets/dd0101bc-2560-4eb2-bf7e-738b66338765)


### Checklist

- [x] I have read and followed the [Pull Requests and Issues guidelines](https://github.com/digitomize/digitomize/blob/main/PR_GUIDELINES.md#pull-requests-and-issues).
- [x] The code has been properly linted and formatted using `npm run lint:fix` and `npm run format:fix`.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, snapshots, and videos after making the changes.
- [x] I have not borrowed code without disclosing it, if applicable.
- [x] This pull request is not a Work In Progress (WIP), and only completed and tested changes are included.
- [x] I have tested these changes locally.
- [x] My code follows the project's style guidelines.
- [x] I have updated the documentation accordingly.
- [x] This PR has a corresponding issue in the issue tracker.

@pranshugupta54 Please review this pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation link active state logic to provide better context awareness for users across related pages like challenges, hackathons, internships, and jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->