### PR TITLE
fix: Improve profile page responsiveness

### DIFF
--- a/client/src/user/Profile/NewUserProfile.jsx
+++ b/client/src/user/Profile/NewUserProfile.jsx
@@ -43,8 +43,8 @@ function NewUserProfile() {
         <meta name="description" content={contentDescription} />
       </Helmet> */}
       <div className="flex mt-8 flex-col md:flex-row w-11/12 mx-auto pb-8">
-        {/* First Column with 450px width */}
-        <div className="flex md:w-[50%]">
+        {/* First Column with flexible max-width */}
+        <div className="flex w-full md:w-auto md:min-w-[400px] md:max-w-[500px] lg:max-w-[550px]">
           <ProfileCard
             username={personal_data.username}
             name={personal_data.name}


### PR DESCRIPTION
## Description
Improved the profile page layout by replacing rigid width constraints with a flexible max-width approach for better responsiveness across different screen sizes.

## Changes
- Replaced `md:w-[50%]` with flexible width classes: `md:w-auto md:min-w-[400px] md:max-w-[500px] lg:max-w-[550px]`
- ProfileCard now has a minimum width of 400px on medium screens for better readability
- Maximum width grows to 500px (md breakpoint) and 550px (lg breakpoint) for improved space utilization
- Mobile devices maintain full width for optimal viewing
- Two-column layout preserved on larger screens with better proportions

## Before & After
**Before:** ProfileCard constrained to 50% width on medium+ screens, causing cramped appearance
**After:** ProfileCard uses flexible max-width (400-550px) providing more comfortable reading experience while maintaining layout

## Testing
- ✅ Tested responsive behavior across breakpoints (mobile, tablet, desktop)
- ✅ Two-column layout maintained on larger screens
- ✅ Profile content displays with proper spacing and alignment
- ✅ No layout breaks or overflow issues

Closes #1106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout of the user profile page with flexible width constraints across different screen sizes, ensuring better adaptability on medium and large displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->