### PR TITLE
fix: open Platform dropdown on hover (Issue #1114)

### DIFF
--- a/client/src/components/Contests/Filter.jsx
+++ b/client/src/components/Contests/Filter.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import formbricks from "@formbricks/js/website";
 
 const handleClick = () => {
@@ -38,6 +38,7 @@ import { Element } from "react-scroll";
 import CustomSlider from "../CustomSlider";
 const backendUrl = import.meta.env.VITE_REACT_APP_BACKEND_URL;
 const MenuProps = {
+  disablePortal: true,
   PaperProps: {
     style: {
       maxHeight: "none",
@@ -74,13 +75,34 @@ function Filter() {
   const [open, setOpen] = useState(false);
   const [range, setRange] = useState([0, 0]);
   const [maxValue, setMaxValue] = useState(Number);
+  const closeTimerRef = useRef(null);
+
+  const handleMouseEnter = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    setOpen(true);
+  };
+
+  const handleMouseLeave = () => {
+    closeTimerRef.current = setTimeout(() => {
+      setOpen(false);
+    }, 150);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
   useEffect(() => {
     // Fetch data from the backend API
     const selectedPlatformsParam = selectedPlatforms.join(",");
     const url = selectedPlatformsParam
       ? `${backendUrl}/contests?host=${selectedPlatformsParam}`
       : `${backendUrl}/contests`;
-      
+
     fetch(url)
       .then((response) => response.json())
       .then((data) => {
@@ -105,7 +127,6 @@ function Filter() {
   };
   const handleChange = (e) => {
     setSelectedPlatforms(e.target.value);
-    setOpen(!open);
   };
   return (
     <>
@@ -114,6 +135,8 @@ function Filter() {
         {/* //checkmarks */}
         <div
           className={"filter-div w-fit self-center bg-cardsColor relative rounded-xl"}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           <FormControl
             variant="filled"
@@ -133,7 +156,8 @@ function Filter() {
               open={open}
               multiple
               value={selectedPlatforms}
-              onClick={!open ? () => setOpen(true) : () => setOpen(false)}
+              onOpen={() => setOpen(true)}
+              onClose={() => setOpen(false)}
               onChange={handleChange}
               input={<OutlinedInput id="select-multiple-chip" label="" />}
               renderValue={(selected) => (
@@ -189,10 +213,10 @@ function Filter() {
           <>
             <p className="mx-auto text-center mt-4 text-xl">
               Have a favorite contest platform we're missing? {" "} Join our <a href="https://digitomize.com/discord" target="_blank" rel="noopener noreferrer" className="text-digitomize-bg">Discord</a> or <button className="text-digitomize-bg" onClick={handleClick}>
-              click here
-            </button> and let us know!
+                click here
+              </button> and let us know!
             </p>
-            
+
             <Contests contests={contestsData} range={range} />
           </>
         ) : (


### PR DESCRIPTION
Fixes #1114

## Summary
Platform dropdown on the Contests page now opens on hover and closes when the cursor leaves.

## Root Cause
MUI's `<Select>` with a controlled `open` prop requires both `onOpen` and `onClose` props to function correctly. Without `onClose`, MUI had no handler to call when the user moved away, so the dropdown never closed. The previous `onClick` toggle also conflicted with hover state.

## Changes
- `client/src/components/Contests/Filter.jsx` only — no other files touched

### What changed
- Replaced `onClick` on `<Select>` with `onOpen` and `onClose` (MUI's controlled API)
- Added `useRef`-based timer in `handleMouseLeave` to prevent flicker when cursor moves from trigger → menu
- Removed `setOpen(!open)` from `handleChange` so platform selection no longer interferes with open state
- Added `useEffect` cleanup to clear the timer on unmount

## Behavior
| Action | Before | After |
|---|---|---|
| Hover over dropdown | Nothing | Opens ✅ |
| Move cursor to menu | Flickered / closed | Stays open ✅ |
| Move cursor away | Never closed | Closes after 150ms ✅ |
| Click a platform | Worked | Still works ✅ |
| Escape / click outside | Worked | Still works ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the platform dropdown so it stays open briefly on hover and closes more smoothly after mouse leave.
  * Fixed dropdown behavior to use clearer open/close handling, reducing accidental closes.
  * Kept the dropdown positioned consistently within the page layout.
  * Updated the Discord call-to-action text formatting without changing its content or links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->